### PR TITLE
added EOS BlockSmith networks; fixed Worbli Testnet chain ID

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -83,6 +83,13 @@
     "network": "telos",
     "endpoints": [
       {
+        "name": "EOS BlockSmith",
+        "protocol": "https",
+        "port": 443,
+        "url": "telos-mainnet.eosblocksmith.io",
+        "description": "EOS BlockSmith Telos Mainnet API"
+      },
+      {
         "name": "CalEOS",
         "protocol": "https",
         "port": 443,
@@ -235,6 +242,13 @@
     "prefix":"TLOS",
     "network": "telos",
     "endpoints": [
+      {
+        "name": "EOS BlockSmith",
+        "protocol": "https",
+        "port": 443,
+        "url": "telos-testnet.eosblocksmith.io",
+        "description": "EOS BlockSmith Telos Testnet API"
+      },
       {
         "name": "EOS Miami",
         "protocol": "https",

--- a/networks.json
+++ b/networks.json
@@ -9,6 +9,13 @@
     "network": "eos",
     "endpoints": [
       {
+        "name": "EOS BlockSmith",
+        "protocol": "https",
+        "port": 443,
+        "url": "eos-mainnet.eosblocksmith.io",
+        "description": "EOS BlockSmith EOS Mainnet API"
+      },
+      {
         "name": "franceos",
         "protocol": "https",
         "port": 443,
@@ -101,6 +108,13 @@
     "network": "eos",
     "endpoints": [
       {
+        "name": "EOS BlockSmith",
+        "protocol": "https",
+        "port": 443,
+        "url": "eos-jungle.eosblocksmith.io",
+        "description": "EOS BlockSmith Jungle Testnet v2 API"
+      },
+      {
         "name": "Aloha EOS",
         "protocol": "https",
         "port": 443,
@@ -166,11 +180,18 @@
     "name": "WORBLI Testnet",
     "description": "WORBLI Testnet",
     "owner": "WORBLI",
-    "chainId": "df2cf1f78b894e667077791e903c0b89091ef9e0e01cd019e4c7f22522794ad0",
+    "chainId": "0d1ba39b44e70e9c36b74d60677ef3b686bd4347ade092b816886a6a35ddb6f7",
     "type": "testnet",
     "prefix":"WBI",
     "network": "worbli",
     "endpoints": [
+      {
+        "name": "EOS BlockSmith",
+        "protocol": "https",
+        "port": 443,
+        "url": "worbli-testnet.eosblocksmith.io",
+        "description": "EOS BlockSmith Worbli Testnet API"
+      },
       {
         "name": "EOSphere",
         "protocol": "https",
@@ -189,6 +210,13 @@
     "prefix":"WBI",
     "network": "worbli",
     "endpoints": [
+      {
+        "name": "EOS BlockSmith",
+        "protocol": "https",
+        "port": 443,
+        "url": "worbli-mainnet.eosblocksmith.io",
+        "description": "EOS BlockSmith Worbli Mainnet API"
+      },
       {
         "name": "Worbli",
         "protocol": "https",


### PR DESCRIPTION
In addition to adding public endpoints for EOS BlockSmith, the Worbli Testnet chain ID was fixed (the testnet was relaunched when the Worbli Mainnet launched).